### PR TITLE
Replace Python with Go in Dockerfile comment

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -28,7 +28,7 @@ RUN go get -x -d github.com/stamblerre/gocode \
     && go build -o gocode-gomod github.com/stamblerre/gocode \
     && mv gocode-gomod $GOPATH/bin/
 
-# Copy default endpoint specific user settings overrides into container to specify Python path
+# Copy default endpoint specific user settings overrides into container to specify Go path
 COPY settings.vscode.json /root/.vscode-remote/data/Machine/settings.json
 
 # Verify git, process tools installed
@@ -38,4 +38,4 @@ RUN apt-get update && apt-get -y install git procps
 RUN apt-get autoremove -y \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
-	
+


### PR DESCRIPTION
A comment in the Dockerfile used to build the dev container indicated the Python path, as opposed to the Go path. This PR simply fixes that comment.