### PR TITLE
Define GOROOT specifically for container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,6 +19,7 @@
 	"settings": { 
 		"terminal.integrated.shell.linux": "/bin/bash",
 		"go.gopath": "/go",
+		"go.goroot": "/usr/local/go",
 		"go.inferGopath": true,
 		"go.useLanguageServer": true
 	},

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 ##
 ## Get latest from https://github.com/github/gitignore/blob/master/VisualStudio.gitignore
 
+# Go debug files
+__debug_bin
+
 # User-specific files
 *.suo
 *.user

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,10 @@
             "type": "go",
             "request": "launch",
             "mode": "debug",
-            "program": "${workspaceFolder}/src/main/server.go"
+            "program": "${workspaceFolder}/src/main/server.go",
+            "env": {
+                "GOROOT": "/usr/local/go"
+            },
         }
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,6 @@
 {
     "go.useLanguageServer": true,
-    "go.inferGopath": true
+    "go.inferGopath": false,
+    "go.gopath": "/go",
+    "go.goroot": "/usr/local/go"
 }


### PR DESCRIPTION
This ensures that the GOROOT variable is defined properly for the container, otherwise the container will inherit from the underlying system which might have a different GOROOT location.