### PR TITLE
Add go src to the cleanup.

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -64,7 +64,10 @@ RUN go get -x -d github.com/stamblerre/gocode 2>&1 \
         honnef.co/go/tools/... \
         github.com/golangci/golangci-lint/cmd/golangci-lint \
         github.com/mgechev/revive \
-        github.com/derekparker/delve/cmd/dlv 2>&1
+        github.com/derekparker/delve/cmd/dlv 2>&1 \
+    #
+    # Clean up
+    && rm -rf /go/src
 
 # Uncomment the line below if you are using go modules
 # ENV GO111MODULE=on


### PR DESCRIPTION
This saves about 130 megs. Not a huge deal if local but if folks end up
pushing to a registry is nice (~>10% reduction).