### PR TITLE
Update with port attributes and various readme updates

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,7 +17,7 @@
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 
 		"terminal.integrated.shell.linux": "/bin/bash",
-		"go.useGoProxyToCheckForToolUpdates": false,
+		"go.toolsManagement.checkForUpdates": "off",
 		"go.gopath": "/go",
 		"go.useLanguageServer": true,
 		"remote.portsAttributes": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,7 +19,13 @@
 		"terminal.integrated.shell.linux": "/bin/bash",
 		"go.useGoProxyToCheckForToolUpdates": false,
 		"go.gopath": "/go",
-		"go.useLanguageServer": true
+		"go.useLanguageServer": true,
+		"remote.portsAttributes": {
+			"9000": {
+				"label": "My Port",
+				"onAutoForward": "notify"
+			}
+		}
 	},
 	
 	// Add the IDs of extensions you want installed when the container is created.

--- a/README.md
+++ b/README.md
@@ -50,9 +50,12 @@ Some things to try:
    - Add a breakpoint (e.g. on line 22).
    - Press <kbd>F5</kbd> to launch the app in the container.
    - Once the breakpoint is hit, try hovering over variables, examining locals, and more.   
-   - Continue (<kbd>F5</kbd>). You can connect to the server in the container by either: clicking on `Running on http://0.0.0.0:9000/` in the terminal output, or "Open in Browser" next to port 9000 in the 'Ports' view (you can get to the 'Ports' view by clicking on the "1" in the status bar, which means your app has 1 forwarded port).
+   - Continue (<kbd>F5</kbd>). You can connect to the server in the container by either: 
+        - Clicking on `Open in Browser` in the notification telling you: `Your service running on port 9000 is available`.
+        - Clicking the globe icon in the 'Ports' view. The 'Ports' view gives you an organized table of your forwarded ports, and you can get there by clicking on the "1" in the status bar, which means your app has 1 forwarded port.
+   - Notice port 9000 in the 'Ports' view is labeled "My Port." In `devcontainer.json`, you can set `"remote.portsAttributes"`, such as a label for your forwarded ports and the action to be taken when the port is autoforwarded.
 
-   > **Note:** In Remote - Containers, you can access your app at `http://localhost:9000` in a local browser. But in a browser-based Codespace, you must click the link from the terminal output or the `Ports` view so that the service handles port forwarding in the browser and generates the correct URL.
+   > **Note:** In Remote - Containers, you can access your app at `http://localhost:9000` in a local browser. But in a browser-based Codespace, you must click the link from the notification or the `Ports` view so that the service handles port forwarding in the browser and generates the correct URL.
    
 4. **Rebuild or update your container:** (*Currently, only containers with the VS Code Remote - Containers extension can be rebuilt.*)
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Some things to try:
 
    > **Note:** In Remote - Containers, you can access your app at `http://localhost:9000` in a local browser. But in a browser-based Codespace, you must click the link from the notification or the `Ports` view so that the service handles port forwarding in the browser and generates the correct URL.
    
-4. **Rebuild or update your container:** (*Currently, only containers with the VS Code Remote - Containers extension can be rebuilt.*)
+4. **Rebuild or update your container:** 
 
    You may want to make changes to your container, such as installing a different version of a software or forwarding a new port. You'll rebuild your container for your changes to take effect. 
 
@@ -67,7 +67,7 @@ Some things to try:
    
    - Open the `.devcontainer/devcontainer.json` file.
    - Uncomment the `forwardedPorts` attribute and adjust the port number as needed.
-   - Press <kbd>F1</kbd> and select the **Remote-Containers: Rebuild Container** command so the modifications are picked up.
+   - Press <kbd>F1</kbd> and select the **Remote-Containers: Rebuild Container** or **Codespaces: Rebuild Container** command so the modifications are picked up.
 5. **Refactoring - rename:**
     - Open `hello.go`, select method name `Hello` press <kbd>F1</kbd> and run the **Rename Symbol** command.
 6. **Refactoring - extract:**


### PR DESCRIPTION
We discussed updating the dev container samples to include the latest remote.portAttributes setting: https://github.com/microsoft/vscode-docs/blob/main/remote-release-notes/v1_53.md#port-attributes.

As I was making the update, I realized some other areas to update:

- Update readme about new [remote ports table](https://github.com/microsoft/vscode-docs/blob/main/remote-release-notes/v1_54.md#ports-view-table-layout), as this now affects port info/access/appearance 
- Codespaces can now be rebuilt
- VS Code notified me to update a Go update package in devcontainer.json

Once we decide which remote.portAttributes settings we'd like to include by default in remote-try-* repos, I can update the other devcontainer.json's and their readme's accordingly. I thought including a "My Port" label and notifying on autoforward made sense, but I'm definitely open to feedback here (and on how we explain it in the readme).

Another question: do we want to update https://github.com/microsoft/vscode-dev-containers/tree/master/containers samples and/or readmes to include remote.portAttributes? I realize we discussed updating "samples" to include these settings, but didn't specify _which_ samples.