### PR TITLE
monthly task update devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 {
 	"name": "Go",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/go:0-1.19-bullseye",
+	"image": "mcr.microsoft.com/devcontainers/go:1-1.21-bullseye",
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},


### PR DESCRIPTION
used tag `1-1.21-bullseye` which pointing to the latest `bullseye` sha for go