### PR TITLE
chore: Bump go version to `1.22`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/microsoft/vscode-remote-try-go
 
-go 1.19
+go 1.22


### PR DESCRIPTION
## Description
This branch introduces a simple patch to the `go` version spec in the `go.mod` file. This PR's primary goal is to sync the `go` version spec in the `go.mod` file with the `go` version for the precompiled [image](https://github.com/microsoft/vscode-remote-try-go/blob/main/.devcontainer/devcontainer.json#L6) for the Dev Container ([maintained](https://github.com/devcontainers/images/tree/a108063b6ff558954c1639871f660a185d86d267/src/go) by Microsoft). From observing the repo's commit history, the template was initialized using `go 1.14` and requires manual user intervention to sync this version with the precompiled image releases from Microsoft.

### Decisions
> This section outlines notable considerations for developers/maintainers.

This patch requiring manual user intervention can be automated with minimal effort using one of the following tools:
- [GitHub Action](https://docs.github.com/en/actions)
- [Custom](https://pre-commit.com/#new-hooks) pre-commit hook

**Example of custom pre-commit hook:**
```
-   id: sync-go-version
    name: Sync Go Version
    description: Syncs go version in mod file with version spec in pre-built image.
    entry: sync-go-version  # bash script with logic to execute
    language: script
    files: \.devcontainer/devcontainer\.json$
    types: [text]
```

## Testing
Tests run: `N/A`

## Additional
- **[Decision]** Both tools recommended have pros and cons. A GitHub action is more centralized and "automated" but involves a more complex setup. A custom pre-commit hook is easier to set up but introduces a dependency on the local developer environment and package installation and configuration (minimal) of [`pre-commit`](https://pre-commit.com/#install).